### PR TITLE
Templates now compatible with AngularUI 0.10.0

### DIFF
--- a/dialogs.js
+++ b/dialogs.js
@@ -101,7 +101,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 	/**
 	 * Dialogs Service 
 	 */
-	.factory('$dialogs',['$modal',function($modal){
+	.factory('dialogs',['$modal',function($modal){
 		return {
 			error : function(msg){
 				return $modal.open({


### PR DESCRIPTION
In the newer versions of AngularUI, only the content of the modal has to be provided, otherwise the modal isn't rendered correctly.
http://angular-ui.github.io/bootstrap/#/modal for reference.
