### PR TITLE
Default strings can now be translated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+.idea/workspace.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+angular-dialog-service

--- a/.idea/angular-dialog-service.iml
+++ b/.idea/angular-dialog-service.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>
+

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectCodeStyleSettingsManager">
+    <option name="PER_PROJECT_SETTINGS">
+      <value>
+        <JSCodeStyleSettings>
+          <option name="SPACE_BEFORE_PROPERTY_COLON" value="true" />
+          <option name="SPACE_BEFORE_FUNCTION_LEFT_PARENTH" value="false" />
+          <option name="REFORMAT_C_STYLE_COMMENTS" value="false" />
+        </JSCodeStyleSettings>
+        <codeStyleSettings language="JavaScript">
+          <option name="SPACE_AFTER_COMMA" value="false" />
+          <option name="SPACE_BEFORE_IF_PARENTHESES" value="false" />
+          <option name="SPACE_BEFORE_WHILE_PARENTHESES" value="false" />
+          <option name="SPACE_BEFORE_FOR_PARENTHESES" value="false" />
+          <option name="SPACE_BEFORE_CATCH_PARENTHESES" value="false" />
+          <option name="SPACE_BEFORE_SWITCH_PARENTHESES" value="false" />
+          <option name="SPACE_BEFORE_METHOD_LBRACE" value="false" />
+          <option name="SPACE_BEFORE_IF_LBRACE" value="false" />
+          <option name="SPACE_BEFORE_ELSE_LBRACE" value="false" />
+          <option name="SPACE_BEFORE_WHILE_LBRACE" value="false" />
+          <option name="SPACE_BEFORE_FOR_LBRACE" value="false" />
+          <option name="SPACE_BEFORE_DO_LBRACE" value="false" />
+          <option name="SPACE_BEFORE_SWITCH_LBRACE" value="false" />
+          <option name="SPACE_BEFORE_TRY_LBRACE" value="false" />
+          <option name="SPACE_BEFORE_CATCH_LBRACE" value="false" />
+          <option name="SPACE_BEFORE_FINALLY_LBRACE" value="false" />
+          <indentOptions>
+            <option name="USE_TAB_CHARACTER" value="true" />
+          </indentOptions>
+        </codeStyleSettings>
+      </value>
+    </option>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </component>
+</project>
+

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false" />
+</project>
+

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" />
+</project>
+

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/angular-dialog-service.iml" filepath="$PROJECT_DIR$/.idea/angular-dialog-service.iml" />
+    </modules>
+  </component>
+</project>
+

--- a/.idea/scopes/scope_settings.xml
+++ b/.idea/scopes/scope_settings.xml
@@ -1,0 +1,5 @@
+<component name="DependencyValidationManager">
+  <state>
+    <option name="SKIP_IMPORT_STATEMENTS" value="false" />
+  </state>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>
+

--- a/dialogs.js
+++ b/dialogs.js
@@ -1,5 +1,5 @@
 /**
- * Note: This version requires Angular UI Bootstrap >= v0.6.0 
+ * Note: This version requires Angular UI Bootstrap >= v0.6.0
  */
 
 //== Controllers =============================================================//
@@ -7,105 +7,109 @@
 angular.module('dialogs.controllers',['ui.bootstrap.modal'])
 
 	/**
-	 * Error Dialog Controller 
+	 * Error Dialog Controller
 	 */
 	.controller('errorDialogCtrl',['$scope','$modalInstance','header','msg','defaultStrings',function($scope,$modalInstance,header,msg,defaultStrings){
 		//-- Variables -----//
-		
-		$scope.header = (angular.isDefined(header)) ? header : 'Error';
-		$scope.msg = (angular.isDefined(msg)) ? msg : 'An unknown error has occurred.';
-		
+
+		$scope.header = (angular.isDefined(header)) ? header : defaultStrings.error;
+		$scope.msg = (angular.isDefined(msg)) ? msg : defaultStrings.errorMessage;
+		$scope.defaultStrings = defaultStrings;
+
 		//-- Methods -----//
-		
+
 		$scope.close = function(){
 			$modalInstance.close();
 			$scope.$destroy();
 		}; // end close
 	}]) // end ErrorDialogCtrl
-	
+
 	/**
-	 * Wait Dialog Controller 
+	 * Wait Dialog Controller
 	 */
 	.controller('waitDialogCtrl',['$scope','$modalInstance','$timeout','header','msg','progress','defaultStrings',function($scope,$modalInstance,$timeout,header,msg,progress,defaultStrings){
 		//-- Variables -----//
-		
-		$scope.header = (angular.isDefined(header)) ? header : 'Please Wait...';
-		$scope.msg = (angular.isDefined(msg)) ? msg : 'Waiting on operation to complete.';
+
+		$scope.header = (angular.isDefined(header)) ? header : defaultStrings.pleaseWaitEllipsis;
+		$scope.msg = (angular.isDefined(msg)) ? msg : defaultStrings.pleaseWaitMessage;
 		$scope.progress = (angular.isDefined(progress)) ? progress : 100;
-		
+		$scope.defaultStrings = defaultStrings;
+
 		//-- Listeners -----//
-		
+
 		// Note: used $timeout instead of $scope.$apply() because I was getting a $$nextSibling error
-		
+
 		// close wait dialog
 		$scope.$on('dialogs.wait.complete',function(){
-			$timeout(function(){ $modalInstance.close(); $scope.$destroy();});
+			$timeout(function(){ $modalInstance.close(); $scope.$destroy(); });
 		}); // end on(dialogs.wait.complete)
-		
+
 		// update the dialog's message
 		$scope.$on('dialogs.wait.message',function(evt,args){
 			$scope.msg = (angular.isDefined(args.msg)) ? args.msg : $scope.msg;
 		}); // end on(dialogs.wait.message)
-		
+
 		// update the dialog's progress (bar) and/or message
 		$scope.$on('dialogs.wait.progress',function(evt,args){
 			$scope.msg = (angular.isDefined(args.msg)) ? args.msg : $scope.msg;
 			$scope.progress = (angular.isDefined(args.progress)) ? args.progress : $scope.progress;
 		}); // end on(dialogs.wait.progress)
-		
+
 		//-- Methods -----//
-		
+
 		$scope.getProgress = function(){
 			return {'width': $scope.progress + '%'};
 		}; // end getProgress
 	}]) // end WaitDialogCtrl
-	
+
 	/**
-	 * Notify Dialog Controller 
+	 * Notify Dialog Controller
 	 */
 	.controller('notifyDialogCtrl',['$scope','$modalInstance','header','msg','defaultStrings',function($scope,$modalInstance,header,msg,defaultStrings){
 		//-- Variables -----//
-		
-		$scope.header = (angular.isDefined(header)) ? header : 'Notification';
-		$scope.msg = (angular.isDefined(msg)) ? msg : 'Unknown application notification.';
-		
+
+		$scope.header = (angular.isDefined(header)) ? header : defaultStrings.notification;
+		$scope.msg = (angular.isDefined(msg)) ? msg : defaultString.notificationMessage;
+		$scope.defaultStrings = defaultStrings;
+
 		//-- Methods -----//
-		
+
 		$scope.close = function(){
 			$modalInstance.close();
 			$scope.$destroy();
 		}; // end close
 	}]) // end WaitDialogCtrl
-	
+
 	/**
-	 * Confirm Dialog Controller 
+	 * Confirm Dialog Controller
 	 */
 	.controller('confirmDialogCtrl',['$scope','$modalInstance','header','msg','defaultStrings',function($scope,$modalInstance,header,msg,defaultStrings){
 		//-- Variables -----//
-		
-		$scope.header = (angular.isDefined(header)) ? header : 'Confirmation';
-		$scope.msg = (angular.isDefined(msg)) ? msg : 'Confirmation required.';
-		
+
+		$scope.header = (angular.isDefined(header)) ? header : defaultStrings.confirmation;
+		$scope.msg = (angular.isDefined(msg)) ? msg : defaultStrings.confirmationMessage;
+		$scope.defaultStrings = defaultStrings;
+
 		//-- Methods -----//
-		
+
 		$scope.no = function(){
 			$modalInstance.dismiss('no');
 		}; // end close
-		
+
 		$scope.yes = function(){
 			$modalInstance.close('yes');
 		}; // end yes
 
     $scope.defaultStrings = defaultStrings;
 	}]); // end ConfirmDialogCtrl / dialogs.controllers
-	
-	
+
+
 //== Services ================================================================//
 
 angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 
 	/**
-	 * Dialogs Service 
+	 * Dialogs Service
 	 */
 	.factory('$dialogs',['$modal',function($modal){
 		return {
@@ -120,7 +124,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 					}
 				}); // end modal.open
 			}, // end error
-			
+
 			wait : function(header,msg,progress){
         var defaultStrings = this.defaultStrings;
 				return $modal.open({
@@ -133,7 +137,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 					}
 				}); // end modal.open
 			}, // end wait
-			
+
 			notify : function(header,msg){
         var defaultStrings = this.defaultStrings;
 				return $modal.open({
@@ -145,7 +149,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 					}
 				}); // end modal.open
 			}, // end notify
-			
+
 			confirm : function(header,msg){
         var defaultStrings = this.defaultStrings;
 				return $modal.open({
@@ -157,7 +161,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 					}
 				}); // end modal.open
 			}, // end confirm
-			
+
 			create : function(url,ctrlr,data,opts){
 				opts = angular.isDefined(opts) ? opts : {};
 				var k = (angular.isDefined(opts.keyboard)) ? opts.keyboard : true; // values: true,false
@@ -168,7 +172,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 					controller : ctrlr,
 					keyboard : k,
 					backdrop : b,
-					windowClass: w,
+					windowClass : w,
 					resolve : {
 						data : function() { return angular.copy(data); }
 					}
@@ -176,8 +180,8 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 			} // end confirm
 		};
 	}]); // end $dialogs / dialogs.services
-	
-	
+
+
 //== Module ==================================================================//
 
 angular.module('dialogs',['dialogs.services','ngSanitize']) // requires angular-sanitize.min.js (ngSanitize) //code.angularjs.org/1.2.1/angular-sanitize.min.js
@@ -190,12 +194,19 @@ angular.module('dialogs',['dialogs.services','ngSanitize']) // requires angular-
 		$templateCache.put('/dialogs/confirm.html','<div class="modal-header dialog-header-confirm"><button type="button" class="close" ng-click="no()">&times;</button><h4 class="modal-title"><span class="glyphicon glyphicon-check"></span> {{header}}</h4></div><div class="modal-body" ng-bind-html="msg"></div><div class="modal-footer"><button type="button" class="btn btn-default" ng-click="yes()">{{defaultStrings.yes}}</button><button type="button" class="btn btn-primary" ng-click="no()">{{defaultStrings.no}}</button></div>');
 	}]); // end run / dialogs
 
-
-angular.module( "dialogs" ).value( "defaultStrings", {
-  close : "Close",
-  pleaseWait : "Please Wait",
-  percentComplete : "% Complete",
-  ok : "OK",
-  yes : "Yes",
-  no : "No"
-} );
+angular.module("dialogs").value("defaultStrings",{
+	error: "Error",
+	errorMessage: "An unknown error has occurred.",
+	close: "Close",
+	pleaseWait: "Please Wait",
+	pleaseWaitEllipsis: "Please Wait...",
+	pleaseWaitMessage: "Waiting on operation to complete.",
+	percentComplete: "% Complete",
+	notification: "Notification",
+	notificationMessage: "Unknown application notification.",
+	confirmation: "Confirmation",
+	confirmationMessage: "Confirmation required.",
+	ok: "OK",
+	yes: "Yes",
+	no: "No"
+});


### PR DESCRIPTION
This adds the ability to translate the strings used in the default dialogs, by simply updating the `defaultStrings` in the module:

```
angular.module( "dialogs" ).value( "defaultStrings", {
  close : "Schließen",
  pleaseWait : "Bitte warten",
  percentComplete : "% fertig",
  ok : "OK",
  yes : "Ja",
  no : "Nein"
} );
```

Any other solution would be just as fine for us :)
