### PR TITLE
Added i18n support

### DIFF
--- a/dialogs.js
+++ b/dialogs.js
@@ -109,7 +109,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 	/**
 	 * Dialogs Service
 	 */
-	.factory('$dialogs',['$modal',function($modal){
+	.factory('$dialogs',['$modal','defaultStrings',function($modal,defaultStrings){
 		return {
 			error : function(header,msg){
 				return $modal.open({
@@ -171,7 +171,11 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 						data : function() { return angular.copy(data); }
 					}
 				}); // end modal.open
-			} // end confirm
+			}, // end create
+
+      translate : function(newStrings){
+        return angular.extend(defaultStrings,newStrings);
+      } // end translate
 		};
 	}]); // end $dialogs / dialogs.services
 


### PR DESCRIPTION
This adds a new provider on the `dialogs` module. This provider contains the collection of all strings used by default in the dialogs.

The `$dialogs` service now exposes a new function `translate`. By calling this function, the user can provide alternative translations to be used.

We integrate dialogs with this translation feature (using [i18n-node-angular](https://github.com/oliversalzburg/i18n-node-angular)) into our application as follows:

```
var myModule = angular.module( "myModule", [
    "dialogs", "i18n"
  ] )
  .config( [
             "$routeProvider", "$locationProvider", "$compileProvider",
             function( $routeProvider, $locationProvider, $compileProvider ) {
                // stuff
             }
           ] )
  .run( [
          "i18n", "$dialogs",
          function( i18n, $dialogs ) {
            i18n.ensureLocaleIsLoaded().then( function() {
              // Retrieve original strings
              var defaultStrings = $dialogs.translate();
              var translated = {};
              for( var translateable in defaultStrings ) {
                translated[ translateable ] = i18n.__( defaultStrings[ translateable ] );
              }
              var result = $dialogs.translate( translated );
            } );
          }
        ] );
```
