### PR TITLE
allowed md value for size attribute #39

### DIFF
--- a/dialogs.js
+++ b/dialogs.js
@@ -116,7 +116,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 			opts = angular.isDefined(opts) ? opts : {};
 			_opts.kb = (angular.isDefined(opts.keyboard)) ? opts.keyboard : _k; // values: true,false
 			_opts.bd = (angular.isDefined(opts.backdrop)) ? opts.backdrop : _b; // values: 'static',true,false
-			_opts.ws = (angular.isDefined(opts.size) && (angular.equals(opts.size,'sm') || angular.equals(opts.size,'lg'))) ? opts.size : _wSize; // values: 'sm', 'lg'
+			_opts.ws = (angular.isDefined(opts.size) && (angular.equals(opts.size,'sm') || angular.equals(opts.size,'lg') || angular.equals(opts.size,'md'))) ? opts.size : _wSize; // values: 'sm', 'lg', 'md'
 			_opts.wc = (angular.isDefined(opts.windowClass)) ? opts.windowClass : _w; // additional CSS class(es) to be added to a modal window
 
 			return _opts;
@@ -187,13 +187,13 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 		/**
 		 * Set Size
 		 *
-		 * Sets the modal size to use (sm,lg), requires Angular-ui-Bootstrap 0.11.0 and Bootstrap 3.1.0 + 
+		 * Sets the modal size to use (sm,lg,md), requires Angular-ui-Bootstrap 0.11.0 and Bootstrap 3.1.0 + 
 		 *
-		 * @param	val 	string (sm,lg)
+		 * @param	val 	string (sm,lg,md)
 		 */
 		this.setSize = function(val){
 			if(angular.isDefined(val))
-				_wSize = (angular.equals(val,'sm') || angular.equals(val,'lg')) ? val : _wSize;
+				_wSize = (angular.equals(val,'sm') || angular.equals(val,'lg') || angular.equals(val,'md')) ? val : _wSize;
 		}; // end setSize
 
 


### PR DESCRIPTION
If you just allow md value for size you can use md sized dialogs because Angular-UI Bootstrap Modal just skip size attribute if it is not lg or sm.
