### PR TITLE
Adding 'npm test' command to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ bower install
 
 For Browser Testing `gulp watch`
 
-For Unit Testing `karma start karma.conf.js`
+For Unit Testing `npm test`
 
 
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
     "karma-phantomjs-launcher": "^0.2.1",
     "phantomjs": "^1.9.18"
   },
+  "scripts": {
+    "test": "karma start karma.conf.js"
+  },
   "licenses": [
     {
       "type": "MIT",


### PR DESCRIPTION
Adding "npm test" command to package.json so users don't need to install karma globally.