### PR TITLE
updated 'main' property to comply with NPM requirements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 require('./dist/dialogs.js');
 require('./dist/dialogs-default-translations.js');
+require('./dist/dialogs.css');
 module.exports = 'dialogs.main';

--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-require('./dist/dialogs.min.js');
-require('./dist/dialogs-default-translations.min.js');
+require('./dist/dialogs.js');
+require('./dist/dialogs-default-translations.js');
 module.exports = 'dialogs.main';

--- a/package.json
+++ b/package.json
@@ -19,10 +19,7 @@
     "type": "git",
     "url": "git://github.com/m-e-conroy/angular-dialog-service"
   },
-  "main": [
-    "./dist/dialogs.min.css",
-    "./index.js"
-  ],
+  "main": "index.js",
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-bump": "^0.3.1",


### PR DESCRIPTION
this change allows the package to be installed via npm.
the property `main` in `package.json` is not valid as an array

the `index.js` has also been updated to not point to the minified files, as this can cause issues when using tools like webpack