### PR TITLE
Determine if selectorText is defined before applying toLowerCase method.

### DIFF
--- a/src/dialogs.js
+++ b/src/dialogs.js
@@ -530,11 +530,10 @@ angular.module('dialogs.main',['dialogs.services','ngSanitize']) // requires ang
 			 			// try to find css rule .fa, in case style sheet has been concatenated
 			 			_rules = _sheets[i].cssRules;
 			 			for(var x = (_rules.length - 1);x >= 0;x--){
-			 				if(typeof(_rules[x].selectorText) !== 'undefined'){
-			 					if(_rules[x].selectorText.toLowerCase() == '.fa'){
-			 						dialogsProvider.useFontAwesome();
-				 					break sheetLoop; // done, exit both for loops
-				 				}
+			 				if(typeof(_rules[x].selectorText) === 'string' && _rules[x].selectorText.toLowerCase() === '.fa'){
+			 					dialogsProvider.useFontAwesome();
+				 				break sheetLoop; // done, exit both for loops
+				 			
 			 				}
 			 			}
 			 		}

--- a/src/dialogs.js
+++ b/src/dialogs.js
@@ -530,9 +530,11 @@ angular.module('dialogs.main',['dialogs.services','ngSanitize']) // requires ang
 			 			// try to find css rule .fa, in case style sheet has been concatenated
 			 			_rules = _sheets[i].cssRules;
 			 			for(var x = (_rules.length - 1);x >= 0;x--){
-			 				if(_rules[x].selectorText.toLowerCase() == '.fa'){
-			 					dialogsProvider.useFontAwesome();
-			 					break sheetLoop; // done, exit both for loops
+			 				if(typeof(_rules[x].selectorText) !== 'undefined'){
+			 					if(_rules[x].selectorText.toLowerCase() == '.fa'){
+			 						dialogsProvider.useFontAwesome();
+				 					break sheetLoop; // done, exit both for loops
+				 				}
 			 				}
 			 			}
 			 		}


### PR DESCRIPTION
When searching for the .fa element attribute, you have rightfully used the toLowerCase method, however I am running across situations where selectorText is undefined, so JavaScript is throwing an exception stating that undefined doesn't have a method toLowerCase. So, I have added a check to make sure that selectorText is defined before your original check.

There may be a better solution to make this cleaner.