### PR TITLE
Added controller as syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ app.controller("MyCtrl", function(dialogs){
 
 ```dialogs.notify('Something Happened','Something happened at this point in the application that I wish to let you know about');```
 
-```dialogs.create('url/to/a/template','ctrlrToUse',{data: topass,anotherVar: 'value'},{});```
+```dialogs.create('url/to/a/template','ctrlrToUse',{data: topass,anotherVar: 'value'},{},'ctrl');```
 
 ### API
 
@@ -61,7 +61,7 @@ All Dialogs return a object with property `result` which is a promise `OK/Yes` r
 
 #### dialogs.create
 
-```dialogs.create(url, ctrlr, data, opts)```
+```dialogs.create(url, ctrlr, data, opts, ctrlAs)```
 
 | Name | Type | Description |
 |---|---|---|
@@ -69,6 +69,7 @@ All Dialogs return a object with property `result` which is a promise `OK/Yes` r
 | ctrlr | `string` | Dialog Controller |
 | data | `object` | data available as a "data" service in the controller |
 | opts | `object<IDialogOptions>` | Options for the dialog with the addition of `copy: false|true` which will copy the data instead of passing reference |
+| ctrlAs | `string` | `controllerAs` reference
 
 #### IDialogOptions Properties
 

--- a/src/dialogs-services.js
+++ b/src/dialogs-services.js
@@ -28,9 +28,9 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 
 		/**
 		 * Use Backdrop
-		 * 
+		 *
 		 * Sets the use of the modal backdrop.  Either to have one or not and
-		 * whether or not it responds to mouse clicks ('static' sets the 
+		 * whether or not it responds to mouse clicks ('static' sets the
 		 * backdrop to true and does not respond to mouse clicks).
 		 *
 		 * @param	val 	mixed	(true, false, 'static')
@@ -42,7 +42,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 
 		/**
 		 * Use ESC Close
-		 * 
+		 *
 		 * Sets the use of the ESC (escape) key to close modal windows.
 		 *
 		 * @param	val 	boolean
@@ -66,7 +66,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 
 		/**
 		 * Use Copy
-		 * 
+		 *
 		 * Determines the use of angular.copy when sending data to the modal controller.
 		 *
 		 * @param	val 	boolean
@@ -91,7 +91,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 		/**
 		 * Set Size
 		 *
-		 * Sets the modal size to use (sm,lg,md), requires Angular-ui-Bootstrap 0.11.0 and Bootstrap 3.1.0 + 
+		 * Sets the modal size to use (sm,lg,md), requires Angular-ui-Bootstrap 0.11.0 and Bootstrap 3.1.0 +
 		 *
 		 * @param	val 	string (sm,lg,md)
 		 */
@@ -121,7 +121,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 
 
 		this.$get = ['$uibModal',function ($uibModal){
-			
+
 			return {
 				/**
 				 * Error Dialog
@@ -153,7 +153,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 						}
 					}); // end modal.open
 				}, // end error
-				
+
 				/**
 				 * Wait Dialog
 				 *
@@ -186,7 +186,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 						}
 					}); // end modal.open
 				}, // end wait
-				
+
 				/**
 				 * Notify Dialog
 				 *
@@ -217,7 +217,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 						}
 					}); // end modal.open
 				}, // end notify
-				
+
 				/**
 				 * Confirm Dialog
 				 *
@@ -248,7 +248,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 						}
 					}); // end modal.open
 				}, // end confirm
-				
+
 				/**
 				 * Create Custom Dialog
 				 *
@@ -257,13 +257,14 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 				 * @param	data 	object
 				 * @param	opts	object
 				 */
-				create : function(url,ctrlr,data,opts){
+				create : function(url,ctrlr,data,opts,ctrlAs){
 					var copy = (opts && angular.isDefined(opts.copy)) ? opts.copy : _copy;
 					opts = _setOpts(opts);
 
 					return $uibModal.open({
 						templateUrl : url,
 						controller : ctrlr,
+						controllerAs : ctrlAs,
 						keyboard : opts.kb,
 						backdrop : opts.bd,
 						backdropClass: opts.bdc,
@@ -271,7 +272,7 @@ angular.module('dialogs.services',['ui.bootstrap.modal','dialogs.controllers'])
 						size: opts.ws,
 						animation: opts.anim,
 						resolve : {
-							data : function() { 
+							data : function() {
 								if(copy)
 									return angular.copy(data);
 								else


### PR DESCRIPTION
added as a 5'th optional parameter to `.create` method, so to not break backwards compatibility
defaults to `ctrl`
see `readme` for details